### PR TITLE
Lmao...

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The actual API will be loaded by PremiumVanish itself.
     <groupId>com.github.LeonMangler</groupId>
     <artifactId>PremiumVanishAPI</artifactId>
     <version>2.7.3</version>
+    <scope>provided</scope>
   </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
[PremiumVanish] A plugin has wrongfully loaded the PremiumVanishAPI dependency! Its developer must not add it to their plugin jar. The actual API comes with PremiumVanish! The API won't work.